### PR TITLE
Find catkin before catkin_package if doing a ROS build

### DIFF
--- a/omd/CMakeLists.txt
+++ b/omd/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(include)
 # Compatiblity with ROS
 if(DEFINED ENV{ROS_ROOT})
   message ("ROS defined -- using catkin ")
+  find_package(catkin REQUIRED)
   catkin_package(INCLUDE_DIRS include)
 else()
   message ("ROS not defined -- not using catkin ")

--- a/optoforce/CMakeLists.txt
+++ b/optoforce/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories(${omd_INCLUDE_DIRS})
 # Compatiblity with ROS
 if(DEFINED ENV{ROS_ROOT})
   message ("ROS defined -- using catkin ")
+  find_package(catkin REQUIRED)
   catkin_package(INCLUDE_DIRS include)
 else()
   message ("ROS not defined -- not using catkin ")


### PR DESCRIPTION
Attempting to build using plain CMake fails at the configure step with the following error.

```bash
$ cmake ../src/optoforce/
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
********************************************
starting cmake management of omd
ROS defined -- using catkin 
CMake Error at omd/CMakeLists.txt:11 (catkin_package):
  Unknown CMake command "catkin_package".


-- Configuring incomplete, errors occurred!
See also "/home/mprada/ros/indigo/sarafun_ros/opbuild/CMakeFiles/CMakeOutput.log".
```

Finding `catkin` before calling the `catkin_package` command seems to fix the issue.