### PR TITLE
Fix build when using catkin_tools

### DIFF
--- a/omd/CMakeLists.txt
+++ b/omd/CMakeLists.txt
@@ -4,13 +4,14 @@ project(omd)
 message ("********************************************")
 message ("starting cmake management of ${PROJECT_NAME}")
 include_directories(include)
-
+find_library(LIBOMD NAMES "OMD" PATHS "${CMAKE_CURRENT_LIST_DIR}/lib/linux")
 
 # Compatiblity with ROS
 if(DEFINED ENV{ROS_ROOT})
   message ("ROS defined -- using catkin ")
   find_package(catkin REQUIRED)
-  catkin_package(INCLUDE_DIRS include)
+  catkin_package(INCLUDE_DIRS include
+    LIBRARIES ${LIBOMD})
 else()
   message ("ROS not defined -- not using catkin ")
 endif()

--- a/omd/CMakeLists.txt
+++ b/omd/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required (VERSION 2.6)
 project(omd)
 
 message ("********************************************")

--- a/optoforce/CMakeLists.txt
+++ b/optoforce/CMakeLists.txt
@@ -81,6 +81,28 @@ install(DIRECTORY include/ DESTINATION include)
 # This makes the project importable from the build directory
 export(TARGETS optoforce FILE optoforceConfig.cmake)
 
+# Compatiblity with ROS
+if(DEFINED ENV{ROS_ROOT})
+  #message ("[${PROJECT_NAME}] ROS defined -- using catkin ")
+  find_package(catkin REQUIRED)
+  #message( "[${PROJECT_NAME}] checking in: ${CMAKE_CURRENT_BINARY_DIR}")
+  find_library(LIBOPTOFORCE NAMES "optoforce" PATHS "${CMAKE_CURRENT_BINARY_DIR}")
+  #message ("[${PROJECT_NAME}] Found ${LIBOPTOFORCE}") 
+
+ catkin_package(INCLUDE_DIRS include
+    #LIBRARIES ${CMAKE_CURRENT_BINARY_DIR}/libdummy2.a
+    LIBRARIES
+    CFG_EXTRAS my-extras.cmake
+    )
+  set_target_properties(
+    ${PROJECT_NAME} PROPERTIES
+    PREFIX "lib"
+    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+    )
+  message("[${PROJECT_NAME}] other library site would be:  ${CATKIN_PACKAGE_LIB_DESTINATION}")
+else()
+  message ("[${PROJECT_NAME}] ROS not defined -- not using catkin ")
+endif()
 
 
 # Creates folder "libraries" and adds target project (math.vcproj)
@@ -103,9 +125,5 @@ export(TARGETS optoforce FILE optoforceConfig.cmake)
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so.1.5 DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so.1 DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
-
-
-message ("********************************************")
-message ("Test: ${optoforce_DIR}")
-message ("********************************************")
-message ("cmake management of ${PROJECT_NAME} done")
+message ("[${PROJECT_NAME}] ********************************************")
+message ("[${PROJECT_NAME}] cmake management of ${PROJECT_NAME} done")

--- a/optoforce/CMakeLists.txt
+++ b/optoforce/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required (VERSION 2.6)
 project(optoforce)
 
-message ("********************************************")
-message ("starting cmake management of ${PROJECT_NAME}")
-
 #todo check if this is the good place for this
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-
+ 
 find_package( Boost REQUIRED COMPONENTS program_options system thread date_time chrono)
 include_directories( ${Boost_INCLUDE_DIR} )
 
@@ -17,40 +14,29 @@ set(SOURCES "src/optoforce_driver.cpp"
   "include/optoforce/optoforce_array_driver.hpp"
   "src/optoforce_acquisition.cpp"
   "include/optoforce/optoforce_acquisition.hpp")
-#todo check this
 # Create named folders for the sources within the .vcproj
 # Empty name lists them directly under the .vcproj
 source_group("optoforce" FILES ${SOURCES})
 # Properties->C/C++->General->Additional Include Directories
 # todo how to skip this, and get omd include  directly from the dependencies
-#include_directories (include ${CMAKE_SOURCE_DIR}/omd/include)
-#include_directories (include ${omd_SOURCE_DIR})
 include_directories(include)
 
-#working version
 list(APPEND CMAKE_MODULE_PATH "${omd_SOURCE_DIR}/cmake")
 find_package(omd)
 
-message("Looking at ${omd_INCLUDE_DIRS}")
-message("Looking at ${omd_SOURCE_DIR}")
-message("Looking at ${omd_LIBRARIES}")
+#message("[${PROJECT_NAME}] Looking at omd include dirs ${omd_INCLUDE_DIRS}")
+#message("[${PROJECT_NAME}] Looking at omd include dirs ${omd_INCLUDES}")
+#message("[${PROJECT_NAME}] Looking at omd source ${omd_SOURCE_DIR}")
+#message("[${PROJECT_NAME}] Looking at omd library ${omd_LIBRARIES}")
+#message("[${PROJECT_NAME}] Looking at omd library ${omd_LIBS}")
 
 add_library(optoforce STATIC ${SOURCES})
 
 include_directories(${omd_INCLUDE_DIRS})
 
-# Compatiblity with ROS
-if(DEFINED ENV{ROS_ROOT})
-  message ("ROS defined -- using catkin ")
-  find_package(catkin REQUIRED)
-  catkin_package(INCLUDE_DIRS include)
-else()
-  message ("ROS not defined -- not using catkin ")
-endif()
-
 target_link_libraries(optoforce ${omd_LIBRARIES})
 
-#adding the examples executables. todo: make this compilation optional
+# adding the examples executables. todo: make this compilation optional
 add_executable(bin_array_opto_force examples/test_opto_device_array.cpp)
 target_link_libraries(bin_array_opto_force optoforce )
 
@@ -62,7 +48,6 @@ target_link_libraries(sample_config_force_acq optoforce  ${Boost_LIBRARIES} yaml
 
 add_executable(test_opto_device_array examples/test_opto_device_array.cpp)
 target_link_libraries(test_opto_device_array optoforce  ${Boost_LIBRARIES} yaml-cpp)
-
 
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
@@ -117,10 +102,9 @@ endif()
 #  RUNTIME DESTINATION ${PROJECT_BINARY_DIR}/bin)
 
 
-#The following lines may be only necessary on Linux ?
+#The following lines may be only necessary on Windows ?
 
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/OMD.dll DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
-
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so.1.5.0 DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so.1.5 DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )
 #file(COPY ${omd_SOURCE_DIR}/lib/linux/libOMD.so.1 DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug )

--- a/optoforce/cmake/my-extras.cmake.in
+++ b/optoforce/cmake/my-extras.cmake.in
@@ -1,0 +1,26 @@
+#find_library(@PROJECT_NAME@_LIBRARY
+#            NAMES @PROJECT_NAME@
+#            #PATHS "${@PROJECT_NAME@_DIR}/../../../@CATKIN_GLOBAL_LIB_DESTINATION@/"
+#            PATHS "${@PROJECT_NAME@_DIR}/../../../../build/@PROJECT_NAME@/"
+#            NO_DEFAULT_PATH)
+
+find_library(@PROJECT_NAME@_LIBRARY
+            NAMES @PROJECT_NAME@
+            #PATHS "${@PROJECT_NAME@_DIR}/../../../@CATKIN_GLOBAL_LIB_DESTINATION@/"
+            PATHS "${@PROJECT_NAME@_DIR}/../../../../build/@PROJECT_NAME@/")
+
+message ("Test here we are")
+message ("Checking for @PROJECT_NAME@ in: ${@PROJECT_NAME@_DIR}/../../../../build/@PROJECT_NAME@/")
+if(@PROJECT_NAME@_LIBRARY)
+  # Multiple CMake projects case (i.e. 'catkin build'):
+  # - The target has already been built when its dependencies require it
+  # - Specify full path to found library
+  message ("catkin build case") 
+  list(APPEND @PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARY})
+else()
+  # Single CMake project case (i.e. 'catkin_make'):
+  # - The target has not been built when its dependencies require it
+  # - Specify target name only
+  message ("catkin_make case") 
+  list(APPEND @PROJECT_NAME@_LIBRARIES @PROJECT_NAME@)
+endif()

--- a/optoforce/package.xml
+++ b/optoforce/package.xml
@@ -10,6 +10,7 @@
   <!--<buildtool_depend>cmake</buildtool_depend>-->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>omd</build_depend>
 
 
 <!--  


### PR DESCRIPTION
Building with [`catkin_tools`](http://catkin-tools.readthedocs.io/en/latest/index.html) currently fails.

First error is because of missing `cmake_minimum_required` statement in `omd/CMakeLists.txt`, which is fixed with c7662c7.

After fixing this, the build still fails with the following output.

```bash
$ catkin build
# ...
Finished  <<< omd                                  [ 1.2 seconds ]                                                                                                                                                                            
______________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
Warnings   << optoforce:cmake /home/mprada/ros/indigo/test_optoforce/logs/optoforce/build.cmake.000.log                                                                                                                                       
********************************************
starting cmake management of optoforce
CMake Warning at /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/CMakeLists.txt:32 (find_package):
  By not providing "Findomd.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "omd", but
  CMake did not find one.

  Could not find a package configuration file provided by "omd" with any of
  the following names:

    omdConfig.cmake
    omd-config.cmake

  Add the installation prefix of "omd" to CMAKE_PREFIX_PATH or set "omd_DIR"
  to a directory containing one of the above files.  If "omd" provides a
  separate development package or SDK, be sure it has been installed.


Looking at
Looking at
Looking at
ROS defined -- using catkin
********************************************
Test:
********************************************
cmake management of optoforce done
cd /home/mprada/ros/indigo/test_optoforce/build/optoforce; catkin build --get-env optoforce | catkin env -si  /usr/bin/cmake /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/mprada/ros/indigo/test_optoforce/devel/.private/optoforce -DCMAKE_INSTALL_PREFIX=/home/mprada/ros/indigo/test_optoforce/install; cd -
..............................................................................................................................................................................................................................................
______________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
Errors     << optoforce:make /home/mprada/ros/indigo/test_optoforce/logs/optoforce/build.make.000.log                                                                                                                                         
In file included from /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/src/optoforce_driver.cpp:15:0:
/home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/include/optoforce/optoforce_driver.hpp:16:25: fatal error: omd/optodaq.h: No such file or directory
 #include "omd/optodaq.h"
                         ^
compilation terminated.
In file included from /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/include/optoforce/optoforce_acquisition.hpp:15:0,
                 from /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/src/optoforce_acquisition.cpp:13:
/home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/include/optoforce/optoforce_driver.hpp:16:25: fatal error: omd/optodaq.h: No such file or directory
 #include "omd/optodaq.h"
                         ^
compilation terminated.
In file included from /home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/src/optoforce_array_driver.cpp:14:0:
/home/mprada/ros/indigo/test_optoforce/src/optoforce/optoforce/include/optoforce/optoforce_array_driver.hpp:15:27: fatal error: omd/optoports.h: No such file or directory
 #include "omd/optoports.h"
                           ^
compilation terminated.
make[2]: *** [CMakeFiles/optoforce.dir/src/optoforce_driver.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/optoforce.dir/src/optoforce_acquisition.cpp.o] Error 1
make[2]: *** [CMakeFiles/optoforce.dir/src/optoforce_array_driver.cpp.o] Error 1
make[1]: *** [CMakeFiles/optoforce.dir/all] Error 2
make: *** [all] Error 2
cd /home/mprada/ros/indigo/test_optoforce/build/optoforce; catkin build --get-env optoforce | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
..............................................................................................................................................................................................................................................
Failed     << optoforce:make                       [ Exited with code 2 ]                                                                                                                                                                     
Failed    <<< optoforce                            [ 1.5 seconds ]                                                                                                                                                                            
[build] Summary: 2 of 3 packages succeeded.                                                                                                                                                                                                   
[build]   Ignored:   None.                                                                                                                                                                                                                    
[build]   Warnings:  2 packages succeeded with warnings.                                                                                                                                                                                      
[build]   Abandoned: None.                                                                                                                                                                                                                    
[build]   Failed:    1 packages failed.                                                                                                                                                                                                       
[build] Runtime: 2.7 seconds total.                                                                                                                                                                                                           
[build] Note: Workspace packages have changed, please re-source setup files to use them.
``` 

Not sure how to proceed with this.